### PR TITLE
Feature/automation app center apk upload

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,3 @@ jobs:
     - name: Build
       run: 
         ./gradlew assembleRelease
-        
-    - name: Test
-      run: 
-        echo "TODO"

--- a/.github/workflows/app-center-apk-upload-ci.yml
+++ b/.github/workflows/app-center-apk-upload-ci.yml
@@ -30,12 +30,12 @@ jobs:
         ./gradlew assembleDebug
 
     - name: upload artefact to App Center
-        uses: wzieba/App-Center-action@v1.0.0
-        with:
-          appName: wzieba/${{ secrets.APP_NAME_DEV }}
-          token: ${{ secrets.APP_CENTER_TOKEN }}
-          group: [${{ secrets.APP_CENTER_GROUPS }}]
-          file: presentation/build/outputs/apk/debug/presentation-debug.apk
+      uses: wzieba/App-Center-action@v1.0.0
+      with:
+        appName: wzieba/${{ secrets.APP_NAME_DEV }}
+        token: ${{ secrets.APP_CENTER_TOKEN }}
+        group: [${{ secrets.APP_CENTER_GROUPS }}]
+        file: presentation/build/outputs/apk/debug/presentation-debug.apk
         
     - name: Test
       run: 

--- a/.github/workflows/app-center-apk-upload-ci.yml
+++ b/.github/workflows/app-center-apk-upload-ci.yml
@@ -30,9 +30,9 @@ jobs:
         ./gradlew assembleDebug
 
     - name: upload artefact to App Center
-      uses: wzieba/App-Center-action@v1.0.0
+      uses: zackify/AppCenter-Github-Action@1.0.0
       with:
-        appName: wzieba/${{ secrets.APP_NAME_DEV }}
+        appName: ${{ secrets.APP_NAME_DEV }}
         token: ${{secrets.APP_CENTER_TOKEN}}
         group: ${{secrets.APP_CENTER_GROUPS}}
         file: presentation/build/outputs/apk/debug/presentation-debug.apk

--- a/.github/workflows/app-center-apk-upload-ci.yml
+++ b/.github/workflows/app-center-apk-upload-ci.yml
@@ -2,7 +2,7 @@ name: Upload apk to the App Center
 
 on:
   push:
-    branches: [ feature/automation-app-center-apk-upload ]
+    branches: [ app-center ]
 
 jobs:
   build:

--- a/.github/workflows/app-center-apk-upload-ci.yml
+++ b/.github/workflows/app-center-apk-upload-ci.yml
@@ -1,0 +1,42 @@
+name: Upload apk to the App Center
+
+on:
+  push:
+    branches: [ app-center ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Prepare Project
+      run: |
+        echo '${{ secrets.GOOGLE_SERVICES_JSON_DEBUG }}' > presentation/src/debug/google-services.json
+        echo '${{ secrets.GOOGLE_SERVICES_JSON_MK }}' > presentation/src/mk/google-services.json
+        mkdir -p presentation/src/release
+        echo '${{ secrets.GOOGLE_SERVICES_JSON_RELEASE }}' > presentation/src/release/google-services.json
+        echo '${{ secrets.GRADLE_PROPERTIES }}' > gradle.properties
+        echo '${{ secrets.TRANSLATIONS_GRADLE }}' > service/translations.gradle
+
+    - name: Static code analysis
+      run: |
+        ./gradlew checkstyle
+        ./gradlew detekt
+
+    - name: Build
+      run: 
+        ./gradlew assembleDebug
+
+    - name: upload artefact to App Center
+        uses: wzieba/App-Center-action@v1.0.0
+        with:
+          appName: wzieba/${{ secrets.APP_NAME_DEV }}
+          token: ${{ secrets.APP_CENTER_TOKEN }}
+          group: [${{ secrets.APP_CENTER_GROUPS }}]
+          file: presentation/build/outputs/apk/debug/presentation-debug.apk
+        
+    - name: Test
+      run: 
+        echo "TODO"

--- a/.github/workflows/app-center-apk-upload-ci.yml
+++ b/.github/workflows/app-center-apk-upload-ci.yml
@@ -29,12 +29,20 @@ jobs:
       run: 
         ./gradlew assembleDebug
 
-    - name: upload artefact to App Center
+    - name: upload artefact to App Center group 1
       uses: zackify/AppCenter-Github-Action@1.0.0
       with:
         appName: ${{ secrets.APP_CENTER_OWNER }}/${{ secrets.APP_NAME_DEV }}
         token: ${{ secrets.APP_CENTER_TOKEN }}
-        group: ${{ secrets.APP_CENTER_GROUPS }}
+        group: ${{ secrets.APP_CENTER_GROUP_1 }}
+        file: presentation/build/outputs/apk/debug/presentation-debug.apk
+
+    - name: upload artefact to App Center group 2
+      uses: zackify/AppCenter-Github-Action@1.0.0
+      with:
+        appName: ${{ secrets.APP_CENTER_OWNER }}/${{ secrets.APP_NAME_DEV }}
+        token: ${{ secrets.APP_CENTER_TOKEN }}
+        group: ${{ secrets.APP_CENTER_GROUP_2 }}
         file: presentation/build/outputs/apk/debug/presentation-debug.apk
         
     - name: Test

--- a/.github/workflows/app-center-apk-upload-ci.yml
+++ b/.github/workflows/app-center-apk-upload-ci.yml
@@ -44,7 +44,3 @@ jobs:
         token: ${{ secrets.APP_CENTER_TOKEN }}
         group: ${{ secrets.APP_CENTER_GROUP_2 }}
         file: presentation/build/outputs/apk/debug/presentation-debug.apk
-        
-    - name: Test
-      run:
-        echo "TODO"

--- a/.github/workflows/app-center-apk-upload-ci.yml
+++ b/.github/workflows/app-center-apk-upload-ci.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         appName: ${{ secrets.APP_CENTER_OWNER }}/${{ secrets.APP_NAME_DEV }}
         token: ${{ secrets.APP_CENTER_TOKEN }}
-        groups: ${{ secrets.APP_CENTER_GROUPS }}
+        group: ${{ secrets.APP_CENTER_GROUPS }}
         file: presentation/build/outputs/apk/debug/presentation-debug.apk
         
     - name: Test

--- a/.github/workflows/app-center-apk-upload-ci.yml
+++ b/.github/workflows/app-center-apk-upload-ci.yml
@@ -38,5 +38,5 @@ jobs:
         file: presentation/build/outputs/apk/debug/presentation-debug.apk
         
     - name: Test
-      run: 
+      run:
         echo "TODO"

--- a/.github/workflows/app-center-apk-upload-ci.yml
+++ b/.github/workflows/app-center-apk-upload-ci.yml
@@ -33,8 +33,8 @@ jobs:
       uses: zackify/AppCenter-Github-Action@1.0.0
       with:
         appName: ${{ secrets.APP_CENTER_OWNER }}/${{ secrets.APP_NAME_DEV }}
-        token: ${{secrets.APP_CENTER_TOKEN}}
-        group: ${{secrets.APP_CENTER_GROUPS}}
+        token: ${{ secrets.APP_CENTER_TOKEN }}
+        group: ${{ secrets.APP_CENTER_GROUPS }}
         file: presentation/build/outputs/apk/debug/presentation-debug.apk
         
     - name: Test

--- a/.github/workflows/app-center-apk-upload-ci.yml
+++ b/.github/workflows/app-center-apk-upload-ci.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         appName: ${{ secrets.APP_CENTER_OWNER }}/${{ secrets.APP_NAME_DEV }}
         token: ${{ secrets.APP_CENTER_TOKEN }}
-        group: ${{ secrets.APP_CENTER_GROUPS }}
+        groups: ${{ secrets.APP_CENTER_GROUPS }}
         file: presentation/build/outputs/apk/debug/presentation-debug.apk
         
     - name: Test

--- a/.github/workflows/app-center-apk-upload-ci.yml
+++ b/.github/workflows/app-center-apk-upload-ci.yml
@@ -2,7 +2,7 @@ name: Upload apk to the App Center
 
 on:
   push:
-    branches: [ app-center ]
+    branches: [ feature/automation-app-center-apk-upload ]
 
 jobs:
   build:

--- a/.github/workflows/app-center-apk-upload-ci.yml
+++ b/.github/workflows/app-center-apk-upload-ci.yml
@@ -33,7 +33,7 @@ jobs:
       uses: wzieba/App-Center-action@v1.0.0
       with:
         appName: wzieba/${{ secrets.APP_NAME_DEV }}
-        token: ${{ secrets.APP_CENTER_TOKEN }}
+        token: ${{secrets.APP_CENTER_TOKEN}}
         group: [${{ secrets.APP_CENTER_GROUPS }}]
         file: presentation/build/outputs/apk/debug/presentation-debug.apk
         

--- a/.github/workflows/app-center-apk-upload-ci.yml
+++ b/.github/workflows/app-center-apk-upload-ci.yml
@@ -32,7 +32,7 @@ jobs:
     - name: upload artefact to App Center
       uses: zackify/AppCenter-Github-Action@1.0.0
       with:
-        appName: ${{ secrets.APP_NAME_DEV }}
+        appName: ${{ secrets.APP_CENTER_OWNER }}/${{ secrets.APP_NAME_DEV }}
         token: ${{secrets.APP_CENTER_TOKEN}}
         group: ${{secrets.APP_CENTER_GROUPS}}
         file: presentation/build/outputs/apk/debug/presentation-debug.apk

--- a/.github/workflows/app-center-apk-upload-ci.yml
+++ b/.github/workflows/app-center-apk-upload-ci.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         appName: wzieba/${{ secrets.APP_NAME_DEV }}
         token: ${{secrets.APP_CENTER_TOKEN}}
-        group: [${{ secrets.APP_CENTER_GROUPS }}]
+        group: ${{secrets.APP_CENTER_GROUPS}}
         file: presentation/build/outputs/apk/debug/presentation-debug.apk
         
     - name: Test

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         minSdkVersion = 21
         targetSdkVersion = 29
 
-        versionCode = System.getenv("BUILD_NUMBER") as Integer ?: 26
+        versionCode = System.getenv("GITHUB_RUN_NUMBER") as Integer ?: 26
         versionName = "1.0.23"
 
         testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         minSdkVersion = 21
         targetSdkVersion = 29
 
-        versionCode = System.getenv("GITHUB_RUN_NUMBER") as Integer ?: 26
-        versionName = "1.0.23"
+        versionCode = System.getenv("GITHUB_RUN_NUMBER") as Integer ?: 1
+        versionName = "1.0.${System.getenv("GITHUB_RUN_NUMBER") ?: "0"}"
 
         testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         minSdkVersion = 21
         targetSdkVersion = 29
 
-        versionCode = System.getenv("BUILD_NUMBER") as Integer ?: 1
-        versionName = "1.0.0"
+        versionCode = System.getenv("BUILD_NUMBER") as Integer ?: 26
+        versionName = "1.0.23"
 
         testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Fixes #
Created new CI workflow to automatically upload .apk file in App Center.

To test:
Upload .apk file to the App Center after push to 'app-center' branch.

PR submission checklist:

- [x] I have followed the [Contributing Guidelines](https://github.com/scalefocus/virusafe-android/blob/master/CONTRIBUTING.md)
- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have described them above.
