### PR TITLE
Feature/add appcenter plugin

### DIFF
--- a/.github/workflows/app-center-apk-upload-ci.yml
+++ b/.github/workflows/app-center-apk-upload-ci.yml
@@ -2,7 +2,7 @@ name: Upload apk to the App Center
 
 on:
   push:
-    branches: [ app-center ]
+    branches: [ feature/add-appcenter-plugin ]
 
 jobs:
   build:
@@ -26,21 +26,7 @@ jobs:
         ./gradlew detekt
 
     - name: Build
-      run: 
-        ./gradlew assembleDebug
+      run: ./gradlew assembleDebug
 
-    - name: upload artefact to App Center group 1
-      uses: zackify/AppCenter-Github-Action@1.0.0
-      with:
-        appName: ${{ secrets.APP_CENTER_OWNER }}/${{ secrets.APP_NAME_DEV }}
-        token: ${{ secrets.APP_CENTER_TOKEN }}
-        group: ${{ secrets.APP_CENTER_GROUP_1 }}
-        file: presentation/build/outputs/apk/debug/presentation-debug.apk
-
-    - name: upload artefact to App Center group 2
-      uses: zackify/AppCenter-Github-Action@1.0.0
-      with:
-        appName: ${{ secrets.APP_CENTER_OWNER }}/${{ secrets.APP_NAME_DEV }}
-        token: ${{ secrets.APP_CENTER_TOKEN }}
-        group: ${{ secrets.APP_CENTER_GROUP_2 }}
-        file: presentation/build/outputs/apk/debug/presentation-debug.apk
+    - name: upload artefact to App Center
+      run: ./gradlew appCenterAssembleAndUploadDebug

--- a/.github/workflows/app-center-apk-upload-ci.yml
+++ b/.github/workflows/app-center-apk-upload-ci.yml
@@ -30,3 +30,9 @@ jobs:
 
     - name: upload artefact to App Center
       run: ./gradlew appCenterAssembleAndUploadDebug
+      env:
+        APP_CENTER_TOKEN: ${{ secrets.APP_CENTER_TOKEN }}
+        APP_CENTER_OWNER: ${{ secrets.APP_CENTER_OWNER }}
+        APP_CENTER_GROUP_1: ${{ secrets.APP_CENTER_GROUP_1 }}
+        APP_CENTER_GROUP_2: ${{ secrets.APP_CENTER_GROUP_2 }}
+        APP_NAME_DEV: ${{ secrets.APP_NAME_DEV }}

--- a/.github/workflows/app-center-apk-upload-ci.yml
+++ b/.github/workflows/app-center-apk-upload-ci.yml
@@ -2,7 +2,7 @@ name: Upload apk to the App Center
 
 on:
   push:
-    branches: [ feature/add-appcenter-plugin ]
+    branches: [ app-center ]
 
 jobs:
   build:

--- a/.github/workflows/app-center-apk-upload-ci.yml
+++ b/.github/workflows/app-center-apk-upload-ci.yml
@@ -31,8 +31,7 @@ jobs:
     - name: upload artefact to App Center
       run: ./gradlew appCenterAssembleAndUploadDebug
       env:
-        APP_CENTER_TOKEN: ${{ secrets.APP_CENTER_TOKEN }}
-        APP_CENTER_OWNER: ${{ secrets.APP_CENTER_OWNER }}
-        APP_CENTER_GROUP_1: ${{ secrets.APP_CENTER_GROUP_1 }}
-        APP_CENTER_GROUP_2: ${{ secrets.APP_CENTER_GROUP_2 }}
+        APPCENTER_API_TOKEN: ${{ secrets.APPCENTER_API_TOKEN }}
+        APPCENTER_OWNER_NAME: ${{ secrets.APPCENTER_OWNER_NAME }}
+        APPCENTER_DISTRIBUTION_GROUPS: ${{ secrets.APPCENTER_DISTRIBUTION_GROUPS }}
         APP_NAME_DEV: ${{ secrets.APP_NAME_DEV }}

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
 
     dependencies {
@@ -69,6 +72,9 @@ buildscript {
 
         //crashlytics
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.0.0-beta04'
+
+        //appcenter plugin
+        classpath "gradle.plugin.com.betomorrow.gradle:appcenter-plugin:1.1.18"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -60,6 +60,7 @@ android {
     }
 }
 
+//apiToken, ownerName and distributionGroups are in app-center-apk-upload-ci.yml
 appcenter {
     notifyTesters = true
     apps {

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.firebase.crashlytics'
+apply plugin: 'com.betomorrow.appcenter'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -56,6 +57,16 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+}
+
+appcenter {
+    releaseNotes = file("../changelog.md")
+    notifyTesters = true
+    apps {
+        debug {
+            appName = System.getenv("APP_NAME_DEV") ?: ""
+        }
     }
 }
 

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -61,7 +61,6 @@ android {
 }
 
 appcenter {
-    releaseNotes = file("../changelog.md")
     notifyTesters = true
     apps {
         debug {

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -61,10 +61,13 @@ android {
 }
 
 appcenter {
+    apiToken = "${System.getenv("APPCENTER_API_TOKEN")}"
+    ownerName = "${System.getenv("APPCENTER_OWNER_NAME")}"
+    distributionGroups = ["${System.getenv("APP_CENTER_GROUP_1")}", "${System.getenv("APP_CENTER_GROUP_2")}"]
     notifyTesters = true
     apps {
         debug {
-            appName = System.getenv("APP_NAME_DEV") ?: ""
+            appName = "${System.getenv("APP_NAME_DEV")}"
         }
     }
 }

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -61,8 +61,8 @@ android {
 }
 
 appcenter {
-    apiToken = "${System.getenv("APPCENTER_API_TOKEN")}"
-    ownerName = "${System.getenv("APPCENTER_OWNER_NAME")}"
+    apiToken = "${System.getenv("APP_CENTER_TOKEN")}"
+    ownerName = "${System.getenv("APP_CENTER_OWNER")}"
     distributionGroups = ["${System.getenv("APP_CENTER_GROUP_1")}", "${System.getenv("APP_CENTER_GROUP_2")}"]
     notifyTesters = true
     apps {

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -61,9 +61,6 @@ android {
 }
 
 appcenter {
-    apiToken = System.getenv("APP_CENTER_TOKEN") ?: ""
-    ownerName = System.getenv("APP_CENTER_OWNER") ?: ""
-    distributionGroups = [System.getenv("APP_CENTER_GROUP_1") ?: "", System.getenv("APP_CENTER_GROUP_2") ?: ""]
     notifyTesters = true
     apps {
         debug {

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -61,13 +61,13 @@ android {
 }
 
 appcenter {
-    apiToken = "${System.getenv("APP_CENTER_TOKEN")}"
-    ownerName = "${System.getenv("APP_CENTER_OWNER")}"
-    distributionGroups = ["${System.getenv("APP_CENTER_GROUP_1")}", "${System.getenv("APP_CENTER_GROUP_2")}"]
+    apiToken = System.getenv("APP_CENTER_TOKEN") ?: ""
+    ownerName = System.getenv("APP_CENTER_OWNER") ?: ""
+    distributionGroups = [System.getenv("APP_CENTER_GROUP_1") ?: "", System.getenv("APP_CENTER_GROUP_2") ?: ""]
     notifyTesters = true
     apps {
         debug {
-            appName = "${System.getenv("APP_NAME_DEV")}"
+            appName = System.getenv("APP_NAME_DEV") ?: ""
         }
     }
 }


### PR DESCRIPTION
Fixes #
Replaced AppCenter-Github-Action@1.0.0 with AppCenter Gradle Plugin.

To test:
Upload .apk file automatically on push to 'app-center' branch.

PR submission checklist:

- [x] I have followed the [Contributing Guidelines](https://github.com/scalefocus/virusafe-android/blob/master/CONTRIBUTING.md)
- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have described them above.
