### PR TITLE
Force downloading localization files from flex backend

### DIFF
--- a/presentation/src/main/java/bg/government/virusafe/app/localization/LocalizationFragment.kt
+++ b/presentation/src/main/java/bg/government/virusafe/app/localization/LocalizationFragment.kt
@@ -13,8 +13,7 @@ import bg.government.virusafe.app.utils.URL_VIRUSAFE_WHY
 import bg.government.virusafe.databinding.FragmentLocalizationBinding
 import bg.government.virusafe.mvvm.fragment.AbstractFragment
 
-class LocalizationFragment :
-	AbstractFragment<FragmentLocalizationBinding, LocalizationViewModel>(), LocaleClickListener {
+class LocalizationFragment : AbstractFragment<FragmentLocalizationBinding, LocalizationViewModel>(), LocaleClickListener {
 
 	private val adapter: LocalizationAdapter = LocalizationAdapter()
 


### PR DESCRIPTION
Fixes: Not downloading new localized strings

To test: New localization

PR submission checklist:

- [x] I have followed the [Contributing Guidelines](https://github.com/scalefocus/virusafe-android/blob/master/CONTRIBUTING.md)
- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have described them above.
